### PR TITLE
Add eurosym

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,4 +101,5 @@ RUN tlmgr update --self &&\
     sectsty \
     adjustbox \
     collectbox \
+    eurosym \
     jknapltx


### PR DESCRIPTION
Error was
! LaTeX Error: File `eurosym.sty' not found.
https://travis-ci.com/TU-Berlin/MaRDI/builds/126965828#L524